### PR TITLE
fix: include program, programStage, trackedEntityType in map request [v35]

### DIFF
--- a/src/api/metadata.js
+++ b/src/api/metadata.js
@@ -86,14 +86,21 @@ export const getListItemFields = () => [
 ]
 
 // Map
-export const getMapFields = () => [
-    `${getIdNameFields({ rename: true }).join(',')}`,
-    'user,longitude,latitude,zoom,basemap',
-    `mapViews[${getFavoriteFields({
+export const getMapFields = () => {
+    const favoriteFields = getFavoriteFields({
         withDimensions: true,
         withOptions: true,
-    })}]`,
-]
+    })
+
+    const teFields =
+        'program[id,displayName~rename(name)],programStage[id,displayName~rename(name)],trackedEntityType[id,displayName~rename(name)]'
+
+    return [
+        `${getIdNameFields({ rename: true }).join(',')}`,
+        'user,longitude,latitude,zoom,basemap',
+        `mapViews[${favoriteFields.concat(teFields)}]`,
+    ]
+}
 
 // Api
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11924

Backport of: #2011

Include program, programStage, and trackedEntityType in the map request. This information is needed for the map legend.