### PR TITLE
fix: use less alarming colors and better layout for No Visualization messages [v37]

### DIFF
--- a/src/components/Item/VisualizationItem/Visualization/MapPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/MapPlugin.js
@@ -1,6 +1,6 @@
 import { useOnlineStatus } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
-import { IconWarningFilled24, Tooltip, colors } from '@dhis2/ui'
+import { IconWarning24, Tooltip, colors } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
 import { MAP } from '../../../../modules/itemTypes'
@@ -114,7 +114,7 @@ const MapPlugin = ({
                             )}
                             placement="right"
                         >
-                            <IconWarningFilled24 color={colors.yellow700} />
+                            <IconWarning24 color={colors.grey400} />
                         </Tooltip>
                     </span>
                 )}

--- a/src/components/Item/VisualizationItem/Visualization/NoVisualizationMessage.js
+++ b/src/components/Item/VisualizationItem/Visualization/NoVisualizationMessage.js
@@ -1,4 +1,4 @@
-import { IconWarningFilled24, colors } from '@dhis2/ui'
+import { IconWarning24, colors } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import classes from './styles/NoVisualizationMessage.module.css'
@@ -7,7 +7,7 @@ const NoVisualizationMessage = ({ message }) => {
     return (
         <p className={classes.container}>
             <span className={classes.icon}>
-                <IconWarningFilled24 color={colors.yellow700} />
+                <IconWarning24 color={colors.grey400} />
             </span>
             <span className={classes.message}>{message}</span>
         </p>

--- a/src/components/Item/VisualizationItem/Visualization/__tests__/__snapshots__/Visualization.spec.js.snap
+++ b/src/components/Item/VisualizationItem/Visualization/__tests__/__snapshots__/Visualization.spec.js.snap
@@ -9,14 +9,14 @@ exports[`renders NoVisMessage when no visualization 1`] = `
       class="icon"
     >
       <svg
-        color="#e56408"
+        color="#d5dde5"
         height="24"
         viewBox="0 0 24 24"
         width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M12.847 2.794l.056.102 8.416 17.674a1 1 0 01-.786 1.423l-.117.007H3.584a1 1 0 01-.947-1.322l.044-.108 8.416-17.674a1 1 0 011.75-.102zM12 18a1 1 0 100 2 1 1 0 000-2zm1-9h-2v7h2z"
+          d="M12.847 2.794l.056.102 8.416 17.674a1 1 0 01-.786 1.423l-.117.007H3.584a1 1 0 01-.947-1.322l.044-.108 8.416-17.674a1 1 0 011.75-.102zM12 5.65L5.167 19.999h13.665zM12 17a1 1 0 110 2 1 1 0 010-2zm1-7v6h-2v-6z"
           fill="currentColor"
         />
       </svg>

--- a/src/components/Item/VisualizationItem/Visualization/styles/MapPlugin.module.css
+++ b/src/components/Item/VisualizationItem/Visualization/styles/MapPlugin.module.css
@@ -1,4 +1,5 @@
 .warningIcon {
+    background-color: var(--colors-white);
     position: absolute;
     bottom: 0;
     left: 0;

--- a/src/components/Item/VisualizationItem/Visualization/styles/NoVisualizationMessage.module.css
+++ b/src/components/Item/VisualizationItem/Visualization/styles/NoVisualizationMessage.module.css
@@ -1,5 +1,8 @@
 .container {
     display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
     margin: 0;
     padding: var(--spacers-dp8);
     position: absolute;
@@ -11,11 +14,12 @@
 .icon {
     display: inline-flex;
     vertical-align: middle;
-    margin-right: var(--spacers-dp8);
+    margin-bottom: var(--spacers-dp8);
 }
 
 .message {
     font-size: 13px;
     font-stretch: normal;
-    line-height: 20px;
+    line-height: 18px;
+    color: var(--colors-grey800);
 }


### PR DESCRIPTION
See  https://github.com/dhis2/dashboard-app/pull/2032 to see what it originally looked like.

![image](https://user-images.githubusercontent.com/6113918/137119960-8ce547c6-e9ac-4459-8140-aa7596ad51d2.png)
