### PR TITLE
fix: maps with ee layers should not load the ee layers when offline

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-09-28T07:35:26.454Z\n"
-"PO-Revision-Date: 2021-09-28T07:35:26.454Z\n"
+"POT-Creation-Date: 2021-10-13T08:31:26.948Z\n"
+"PO-Revision-Date: 2021-10-13T08:31:26.948Z\n"
 
 msgid "Untitled dashboard"
 msgstr "Untitled dashboard"
@@ -79,6 +79,12 @@ msgstr "View as Map"
 
 msgid "There was a problem loading interpretations for this item"
 msgstr "There was a problem loading interpretations for this item"
+
+msgid "Maps with only Earth Engine layers cannot be displayed when offline"
+msgstr "Maps with only Earth Engine layers cannot be displayed when offline"
+
+msgid "Earth Engine layers on this map cannot be loaded while offline"
+msgstr "Earth Engine layers on this map cannot be loaded while offline"
 
 msgid "Unable to load the plugin for this item"
 msgstr "Unable to load the plugin for this item"

--- a/src/components/Item/VisualizationItem/Visualization/DefaultPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/DefaultPlugin.js
@@ -9,6 +9,7 @@ const DefaultPlugin = ({
     item,
     activeType,
     filterVersion,
+    mapViewCount,
     visualization,
     options,
     style,
@@ -23,6 +24,7 @@ const DefaultPlugin = ({
     const prevItem = useRef()
     const prevActiveType = useRef()
     const prevFilterVersion = useRef()
+    const prevMapViewCount = useRef()
 
     useEffect(() => {
         load(item, visualization, {
@@ -34,6 +36,7 @@ const DefaultPlugin = ({
         prevItem.current = item
         prevActiveType.current = activeType
         prevFilterVersion.current = filterVersion
+        prevMapViewCount.current = mapViewCount
 
         return () => unmount(item, item.type || activeType)
     }, [])
@@ -42,11 +45,14 @@ const DefaultPlugin = ({
         if (
             prevItem.current === item &&
             (prevActiveType.current !== activeType ||
-                prevFilterVersion.current !== filterVersion)
+                prevFilterVersion.current !== filterVersion ||
+                prevMapViewCount.current < mapViewCount)
         ) {
             /* Item is the same but type or filters has changed
+             * or map was previously loaded with fewer mapViews
              * so necessary to reload
              */
+
             load(item, visualization, {
                 credentials,
                 activeType,
@@ -57,7 +63,7 @@ const DefaultPlugin = ({
         prevItem.current = item
         prevActiveType.current = activeType
         prevFilterVersion.current = filterVersion
-    }, [item, visualization, activeType, filterVersion])
+    }, [item, visualization, activeType, filterVersion, mapViewCount])
 
     return <div id={getVisualizationContainerDomId(item.id)} style={style} />
 }
@@ -66,6 +72,7 @@ DefaultPlugin.propTypes = {
     activeType: PropTypes.string,
     filterVersion: PropTypes.string,
     item: PropTypes.object,
+    mapViewCount: PropTypes.number,
     options: PropTypes.object,
     style: PropTypes.object,
     visualization: PropTypes.object,

--- a/src/components/Item/VisualizationItem/Visualization/MapPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/MapPlugin.js
@@ -1,6 +1,6 @@
 import { useOnlineStatus } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
-import { IconWarningFilled24, Tooltip, colors } from '@dhis2/ui'
+import { IconWarning24, Tooltip, colors } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
 import { MAP } from '../../../../modules/itemTypes'
@@ -114,7 +114,7 @@ const MapPlugin = ({
                             )}
                             placement="right"
                         >
-                            <IconWarningFilled24 color={colors.yellow700} />
+                            <IconWarning24 color={colors.grey400} />
                         </Tooltip>
                     </span>
                 )}

--- a/src/components/Item/VisualizationItem/Visualization/MapPlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/MapPlugin.js
@@ -1,13 +1,18 @@
 import { useOnlineStatus } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
+import { IconWarningFilled24, Tooltip, colors } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React, { useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { MAP } from '../../../../modules/itemTypes'
 import getVisualizationContainerDomId from '../getVisualizationContainerDomId'
 import { isElementFullscreen } from '../isElementFullscreen'
 import DefaultPlugin from './DefaultPlugin'
 import NoVisualizationMessage from './NoVisualizationMessage'
 import { pluginIsAvailable, getPlugin, unmount } from './plugin'
+import classes from './styles/MapPlugin.module.css'
+
+const mapViewIsThematicOrEvent = mapView =>
+    mapView.layer.includes('thematic') || mapView.layer.includes('event')
 
 const MapPlugin = ({
     visualization,
@@ -19,6 +24,7 @@ const MapPlugin = ({
     ...props
 }) => {
     const { offline } = useOnlineStatus()
+    const [initialized, setInitialized] = useState(false)
 
     useEffect(() => {
         const resizeMap = async (id, isFullscreen) => {
@@ -39,6 +45,8 @@ const MapPlugin = ({
             plugin?.setOfflineStatus && plugin.setOfflineStatus(offlineStatus)
         }
 
+        !offline && setInitialized(true)
+
         setMapOfflineStatus(offline)
     }, [offline])
 
@@ -46,16 +54,18 @@ const MapPlugin = ({
         if (props.item.type === MAP) {
             // apply filters only to thematic and event layers
             // for maps AO
-            const mapViews = visualization.mapViews.map(mapView => {
-                if (
-                    mapView.layer.includes('thematic') ||
-                    mapView.layer.includes('event')
-                ) {
-                    return applyFilters(mapView, itemFilters)
-                }
+            const mapViews = visualization.mapViews
+                .map(mapView => {
+                    if (mapViewIsThematicOrEvent(mapView)) {
+                        return applyFilters(mapView, itemFilters)
+                    }
 
-                return mapView
-            })
+                    return mapView
+                })
+                .filter(
+                    mapView =>
+                        !offline || !mapView.layer.includes('earthEngine')
+                )
 
             return {
                 ...visualization,
@@ -69,14 +79,46 @@ const MapPlugin = ({
         }
     }
 
+    if (
+        offline &&
+        !initialized &&
+        !visualization.mapViews?.find(mapViewIsThematicOrEvent)
+    ) {
+        return (
+            <NoVisualizationMessage
+                message={i18n.t(
+                    'Maps with only Earth Engine layers cannot be displayed when offline'
+                )}
+            />
+        )
+    }
+
+    const vis = getVisualization()
     return pluginIsAvailable(MAP) ? (
-        <DefaultPlugin
-            options={{
-                hideTitle: true,
-            }}
-            {...props}
-            visualization={getVisualization()}
-        />
+        <>
+            <DefaultPlugin
+                options={{
+                    hideTitle: true,
+                }}
+                {...props}
+                visualization={vis}
+                mapViewCount={vis.mapViews?.length}
+            />
+            {offline &&
+                !initialized &&
+                vis.mapViews?.length !== visualization.mapViews?.length && (
+                    <span className={classes.warningIcon}>
+                        <Tooltip
+                            content={i18n.t(
+                                'Earth Engine layers on this map cannot be loaded while offline'
+                            )}
+                            placement="right"
+                        >
+                            <IconWarningFilled24 color={colors.yellow700} />
+                        </Tooltip>
+                    </span>
+                )}
+        </>
     ) : (
         <NoVisualizationMessage
             message={i18n.t('Unable to load the plugin for this item')}

--- a/src/components/Item/VisualizationItem/Visualization/NoVisualizationMessage.js
+++ b/src/components/Item/VisualizationItem/Visualization/NoVisualizationMessage.js
@@ -1,9 +1,17 @@
+import { IconWarningFilled24, colors } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import classes from './styles/NoVisualizationMessage.module.css'
 
 const NoVisualizationMessage = ({ message }) => {
-    return <div className={classes.message}>{message}</div>
+    return (
+        <p className={classes.container}>
+            <span className={classes.icon}>
+                <IconWarningFilled24 color={colors.yellow700} />
+            </span>
+            <span className={classes.message}>{message}</span>
+        </p>
+    )
 }
 
 NoVisualizationMessage.propTypes = {

--- a/src/components/Item/VisualizationItem/Visualization/NoVisualizationMessage.js
+++ b/src/components/Item/VisualizationItem/Visualization/NoVisualizationMessage.js
@@ -1,4 +1,4 @@
-import { IconWarningFilled24, colors } from '@dhis2/ui'
+import { IconWarning24, colors } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import classes from './styles/NoVisualizationMessage.module.css'
@@ -7,7 +7,7 @@ const NoVisualizationMessage = ({ message }) => {
     return (
         <p className={classes.container}>
             <span className={classes.icon}>
-                <IconWarningFilled24 color={colors.yellow700} />
+                <IconWarning24 color={colors.grey400} />
             </span>
             <span className={classes.message}>{message}</span>
         </p>

--- a/src/components/Item/VisualizationItem/Visualization/__tests__/__snapshots__/Visualization.spec.js.snap
+++ b/src/components/Item/VisualizationItem/Visualization/__tests__/__snapshots__/Visualization.spec.js.snap
@@ -9,14 +9,14 @@ exports[`renders NoVisMessage when no visualization 1`] = `
       class="icon"
     >
       <svg
-        color="#e56408"
+        color="#d5dde5"
         height="24"
         viewBox="0 0 24 24"
         width="24"
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M12.847 2.794l.056.102 8.416 17.674a1 1 0 01-.786 1.423l-.117.007H3.584a1 1 0 01-.947-1.322l.044-.108 8.416-17.674a1 1 0 011.75-.102zM12 18a1 1 0 100 2 1 1 0 000-2zm1-9h-2v7h2z"
+          d="M12.847 2.794l.056.102 8.416 17.674a1 1 0 01-.786 1.423l-.117.007H3.584a1 1 0 01-.947-1.322l.044-.108 8.416-17.674a1 1 0 011.75-.102zM12 5.65L5.167 19.999h13.665zM12 17a1 1 0 110 2 1 1 0 010-2zm1-7v6h-2v-6z"
           fill="currentColor"
         />
       </svg>

--- a/src/components/Item/VisualizationItem/Visualization/__tests__/__snapshots__/Visualization.spec.js.snap
+++ b/src/components/Item/VisualizationItem/Visualization/__tests__/__snapshots__/Visualization.spec.js.snap
@@ -2,11 +2,31 @@
 
 exports[`renders NoVisMessage when no visualization 1`] = `
 <div>
-  <div
-    class="message"
+  <p
+    class="container"
   >
-    No data to display
-  </div>
+    <span
+      class="icon"
+    >
+      <svg
+        color="#e56408"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12.847 2.794l.056.102 8.416 17.674a1 1 0 01-.786 1.423l-.117.007H3.584a1 1 0 01-.947-1.322l.044-.108 8.416-17.674a1 1 0 011.75-.102zM12 18a1 1 0 100 2 1 1 0 000-2zm1-9h-2v7h2z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <span
+      class="message"
+    >
+      No data to display
+    </span>
+  </p>
 </div>
 `;
 

--- a/src/components/Item/VisualizationItem/Visualization/styles/MapPlugin.module.css
+++ b/src/components/Item/VisualizationItem/Visualization/styles/MapPlugin.module.css
@@ -1,4 +1,5 @@
 .warningIcon {
+    background-color: var(--colors-white);
     position: absolute;
     bottom: 0;
     left: 0;

--- a/src/components/Item/VisualizationItem/Visualization/styles/MapPlugin.module.css
+++ b/src/components/Item/VisualizationItem/Visualization/styles/MapPlugin.module.css
@@ -1,0 +1,5 @@
+.warningIcon {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+}

--- a/src/components/Item/VisualizationItem/Visualization/styles/NoVisualizationMessage.module.css
+++ b/src/components/Item/VisualizationItem/Visualization/styles/NoVisualizationMessage.module.css
@@ -1,6 +1,21 @@
+.container {
+    display: flex;
+    margin: 0;
+    padding: var(--spacers-dp8);
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.icon {
+    display: inline-flex;
+    vertical-align: middle;
+    margin-right: var(--spacers-dp8);
+}
+
 .message {
-    font-size: 14px;
+    font-size: 13px;
     font-stretch: normal;
-    padding: 10px;
     line-height: 20px;
 }

--- a/src/components/Item/VisualizationItem/Visualization/styles/NoVisualizationMessage.module.css
+++ b/src/components/Item/VisualizationItem/Visualization/styles/NoVisualizationMessage.module.css
@@ -1,5 +1,8 @@
 .container {
     display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
     margin: 0;
     padding: var(--spacers-dp8);
     position: absolute;
@@ -11,11 +14,12 @@
 .icon {
     display: inline-flex;
     vertical-align: middle;
-    margin-right: var(--spacers-dp8);
+    margin-bottom: var(--spacers-dp8);
 }
 
 .message {
     font-size: 13px;
     font-stretch: normal;
-    line-height: 20px;
+    line-height: 18px;
+    color: var(--colors-grey800);
 }


### PR DESCRIPTION
Fixes https://jira.dhis2.org/browse/DHIS2-11908

Earth Engine layers cannot be loaded while offline. If possible, the map will still be shown, but without the EE layers.

Backport of https://github.com/dhis2/dashboard-app/pull/2032