### PR TITLE
fix: username is needed to fetch preferred dashboard [v37]

### DIFF
--- a/cypress/integration/view/view_dashboard.feature
+++ b/cypress/integration/view/view_dashboard.feature
@@ -43,14 +43,14 @@ Feature: Viewing dashboards
         Given I open the "Delivery" dashboard with shapes removed
         Then the "Delivery" dashboard displays in view mode
 
-    @mutating
+    @nonmutating
     Scenario: I expand the control bar
         Given I open the "Delivery" dashboard
         Then the control bar should be at collapsed height
         When I toggle show more dashboards
         Then the control bar should be expanded to full height
 
-    @mutating
+    @nonmutating
     Scenario: I expand the control bar when dashboard not found
         Given I type an invalid dashboard id in the browser url
         Then a message displays informing that the dashboard is not found
@@ -58,11 +58,20 @@ Feature: Viewing dashboards
         When I toggle show more dashboards
         Then the control bar should be expanded to full height
 
-    @mutating
+    @nonmutating
     Scenario: Maps with tracked entities show layer names in legend
         Given I open the Cases Malaria dashboard
         When I hover over the map legend button
         Then the legend title shows the tracked entity name
+
+    @nonmutating
+    Scenario: User's preferred dashboard is opened
+        Given I open the "Antenatal Care" dashboard
+        When I open the dashboard app with the root url
+        And I open the "Delivery" dashboard
+        And I open the dashboard app with the root url
+        Then the "Delivery" dashboard displays
+
 
 # TODO: flaky test
 # @mutating

--- a/cypress/integration/view/view_dashboard/open_dashboard_app.js
+++ b/cypress/integration/view/view_dashboard/open_dashboard_app.js
@@ -1,0 +1,24 @@
+import { When, Then } from 'cypress-cucumber-preprocessor/steps'
+import {
+    dashboardTitleSel,
+    dashboardChipSel,
+} from '../../../elements/viewDashboard'
+import { EXTENDED_TIMEOUT } from '../../../support/utils'
+
+When('I open the dashboard app with the root url', () => {
+    cy.visit('/', EXTENDED_TIMEOUT)
+
+    cy.location().should(loc => {
+        expect(loc.hash).to.equal('#/')
+    })
+
+    cy.get(dashboardTitleSel).should('be.visible')
+    cy.get(dashboardChipSel, EXTENDED_TIMEOUT).should('be.visible')
+})
+
+Then('the {string} dashboard displays', title => {
+    cy.get(dashboardTitleSel).should('be.visible').and('contain', title)
+    cy.location().should(loc => {
+        expect(loc.hash).to.equal('#/')
+    })
+})

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,3 +1,4 @@
+import { useD2 } from '@dhis2/app-runtime-adapter-d2'
 import { CssVariables } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
@@ -16,6 +17,8 @@ import 'react-resizable/css/styles.css'
 import './styles/ItemGrid.css'
 
 const App = props => {
+    const { d2 } = useD2()
+
     useEffect(() => {
         props.fetchDashboards()
         props.setControlBarRows()
@@ -40,7 +43,12 @@ const App = props => {
                     <Route
                         exact
                         path="/"
-                        render={props => <ViewDashboard {...props} />}
+                        render={props => (
+                            <ViewDashboard
+                                {...props}
+                                username={d2.currentUser.username}
+                            />
+                        )}
                     />
                     <Route
                         exact
@@ -50,7 +58,12 @@ const App = props => {
                     <Route
                         exact
                         path="/:dashboardId"
-                        render={props => <ViewDashboard {...props} />}
+                        render={props => (
+                            <ViewDashboard
+                                {...props}
+                                username={d2.currentUser.username}
+                            />
+                        )}
                     />
                     <Route
                         exact


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12020

Pass username to ViewDashboard, which needs it in redux connect to get the preferred dashboard id from local storage