### PR TITLE
fix: do not include fields more than once in api request

### DIFF
--- a/src/api/fetchDashboard.js
+++ b/src/api/fetchDashboard.js
@@ -28,7 +28,6 @@ const baseDashboardFields = arrayClean([
     'id',
     'displayName',
     'displayDescription',
-    'favorite~rename(starred)',
     'access',
     'restrictFilters',
     'allowedFilters',
@@ -41,7 +40,10 @@ export const viewDashboardQuery = {
     resource: 'dashboards',
     id: ({ id }) => id,
     params: {
-        fields: baseDashboardFields,
+        fields: arrayClean([
+            ...baseDashboardFields,
+            'favorite~rename(starred)',
+        ]),
     },
 }
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12859

A recent change in the api revealed that dashboard was including the `favorite` field twice in the GET request for dashboard when editing. Solution is to make sure to only include the field once

https://user-images.githubusercontent.com/6113918/158381666-e49a7e11-145c-481d-8f73-3a5b713304ed.mov

.