### PR TITLE
feat(iframe-plugin): receive pwa installation status from plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "cy:capture": "cypress_dhis2_api_stub_mode=CAPTURE yarn d2-utils-cypress run --appStart 'yarn cypress:start'"
     },
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^10.3.5",
+        "@dhis2/cli-app-scripts": "^10.3.7",
         "@dhis2/cli-style": "^10.5.1",
         "@dhis2/cli-utils-cypress": "^7.0.1",
         "@dhis2/cypress-commands": "^7.0.1",

--- a/src/actions/iframePluginStatus.js
+++ b/src/actions/iframePluginStatus.js
@@ -1,0 +1,6 @@
+import { ADD_IFRAME_PLUGIN_STATUS } from '../reducers/iframePluginStatus.js'
+
+export const acAddIframePluginStatus = (value) => ({
+    type: ADD_IFRAME_PLUGIN_STATUS,
+    value,
+})

--- a/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
@@ -26,6 +26,9 @@ const IframePlugin = ({
     itemId,
     itemType,
 }) => {
+    // TODO: Access plugin installation status
+    // TODO: Access 'first plugins of their type' for this dashboard
+
     const { d2 } = useD2()
     const { baseUrl } = useConfig()
 
@@ -151,6 +154,8 @@ const IframePlugin = ({
                     window: iframeRef.current.contentWindow,
                 },
                 (event) => {
+                    // TODO: Update plugin installation status for this type
+
                     console.log(
                         'got installationStatus message; data:',
                         event.data
@@ -184,6 +189,12 @@ const IframePlugin = ({
             </div>
         )
     }
+
+    // TODO: if installationStatus === 'UNKNOWN' or 'INSTALLING':
+    // render iframe if this is the first plugin of its type on this dashboard.
+    // otherwise, render a loading spinner
+
+    // TODO: if installationStatus === 'READY' or null, load iframe normally
 
     return (
         <div className={classes.wrapper}>

--- a/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
@@ -1,6 +1,6 @@
 import { useConfig } from '@dhis2/app-runtime'
 import { useD2 } from '@dhis2/app-runtime-adapter-d2'
-import { Layer, CenteredContent, CircularLoader } from '@dhis2/ui'
+import { CenteredContent, CircularLoader } from '@dhis2/ui'
 import postRobot from '@krakenjs/post-robot'
 import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'

--- a/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
@@ -218,11 +218,9 @@ const IframePlugin = ({
         !isFirstOfType
     ) {
         return (
-            <Layer>
-                <CenteredContent>
-                    <CircularLoader />
-                </CenteredContent>
-            </Layer>
+            <CenteredContent>
+                <CircularLoader />
+            </CenteredContent>
         )
     }
 

--- a/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
+++ b/src/components/Item/VisualizationItem/Visualization/IframePlugin.js
@@ -144,6 +144,25 @@ const IframePlugin = ({
     }, [recordOnNextLoad, pluginProps, iframeSrc])
 
     useEffect(() => {
+        if (iframeRef?.current) {
+            const listener = postRobot.on(
+                'installationStatus',
+                {
+                    window: iframeRef.current.contentWindow,
+                },
+                (event) => {
+                    console.log(
+                        'got installationStatus message; data:',
+                        event.data
+                    )
+                }
+            )
+
+            return () => listener.cancel()
+        }
+    }, [])
+
+    useEffect(() => {
         setError(null)
     }, [filterVersion, visualization.type])
 

--- a/src/components/Item/VisualizationItem/Visualization/Visualization.js
+++ b/src/components/Item/VisualizationItem/Visualization/Visualization.js
@@ -82,6 +82,7 @@ const Visualization = ({
             dashboardId,
             itemId: item.id,
             itemType: item.type,
+            isFirstOfType: Boolean(item.firstOfType),
         }),
         [
             originalType,
@@ -92,6 +93,7 @@ const Visualization = ({
             dashboardId,
             item.id,
             item.type,
+            item.firstOfType,
         ]
     )
 

--- a/src/modules/__tests__/getFirstOfType.spec.js
+++ b/src/modules/__tests__/getFirstOfType.spec.js
@@ -1,0 +1,33 @@
+import { getFirstOfTypes } from '../getFirstOfType.js'
+
+describe('getFirstOfTypes', () => {
+    test('returns an empty array if no items are passed', () => {
+        expect(getFirstOfTypes([])).toEqual([])
+    })
+
+    test('returns only ids for types in the array', () => {
+        expect(
+            getFirstOfTypes([
+                { id: 'map2', type: 'MAP', x: 1, y: 1 },
+                { id: 'map1', type: 'MAP', x: 2, y: 0 },
+            ])
+        ).toEqual(['map1'])
+    })
+
+    test('returns first IDs for MAP, VISUALIZATION and EVENT_VISUALIZATION', () => {
+        expect(
+            getFirstOfTypes([
+                { id: 'map2', type: 'MAP', x: 2, y: 2 },
+                { id: 'map1', type: 'MAP', x: 1, y: 1 },
+                { id: 'map0', type: 'MAP', x: 2, y: 0 },
+                { id: 'vis1', type: 'CHART', x: 1, y: 1 },
+                { id: 'vis0', type: 'REPORT_TABLE', x: 1, y: 0 },
+                { id: 'vis2', type: 'VISUALIZATION', x: 2, y: 1 },
+                { id: 'text1', type: 'TEXT', x: 0, y: 0 },
+                { id: 'ev2', type: 'EVENT_VISUALIZATION', x: 0, y: 3 },
+                { id: 'ev1', type: 'EVENT_VISUALIZATION', x: 1, y: 2 },
+                { id: 'ev0', type: 'EVENT_VISUALIZATION', x: 0, y: 2 },
+            ])
+        ).toEqual(['map0', 'ev0', 'vis0'])
+    })
+})

--- a/src/modules/getFirstOfType.js
+++ b/src/modules/getFirstOfType.js
@@ -1,0 +1,31 @@
+import sortBy from 'lodash/sortBy.js'
+import {
+    MAP,
+    VISUALIZATION,
+    EVENT_VISUALIZATION,
+    REPORT_TABLE,
+    CHART,
+} from './itemTypes.js'
+
+export const getFirstOfTypes = (items) => {
+    const firstOfTypes = {}
+
+    firstOfTypes[MAP] = sortBy(
+        items.filter((item) => item.type === MAP),
+        ['y', 'x']
+    )[0]?.id
+
+    firstOfTypes[EVENT_VISUALIZATION] = sortBy(
+        items.filter((item) => item.type === EVENT_VISUALIZATION),
+        ['y', 'x']
+    )[0]?.id
+
+    firstOfTypes[VISUALIZATION] = sortBy(
+        items.filter((item) =>
+            [VISUALIZATION, REPORT_TABLE, CHART].includes(item.type)
+        ),
+        ['y', 'x']
+    )[0]?.id
+
+    return Object.values(firstOfTypes).filter((id) => id !== undefined)
+}

--- a/src/pages/edit/ItemGrid.js
+++ b/src/pages/edit/ItemGrid.js
@@ -10,6 +10,7 @@ import NoContentMessage from '../../components/NoContentMessage.js'
 import ProgressiveLoadingContainer from '../../components/ProgressiveLoadingContainer.js'
 import { useWindowDimensions } from '../../components/WindowDimensionsProvider.js'
 import { EDIT } from '../../modules/dashboardModes.js'
+import { getFirstOfTypes } from '../../modules/getFirstOfType.js'
 import { getGridItemDomElementClassName } from '../../modules/getGridItemDomElementClassName.js'
 import {
     GRID_ROW_HEIGHT_PX,
@@ -38,6 +39,7 @@ const EditItemGrid = ({
 }) => {
     const [gridWidth, setGridWidth] = useState({ width: 0 })
     const { width } = useWindowDimensions()
+    const firstOfTypes = getFirstOfTypes(dashboardItems)
 
     const onLayoutChange = (newLayout) => {
         acUpdateDashboardItemShapes(newLayout)
@@ -46,23 +48,28 @@ const EditItemGrid = ({
     const onWidthChanged = (containerWidth) =>
         setTimeout(() => setGridWidth({ width: containerWidth }), 200)
 
-    const getItemComponent = (item) => (
-        <ProgressiveLoadingContainer
-            key={item.i}
-            className={cx(
-                item.type,
-                'edit',
-                getGridItemDomElementClassName(item.id)
-            )}
-            itemId={item.id}
-        >
-            <Item
-                item={item}
-                gridWidth={gridWidth.width}
-                dashboardMode={EDIT}
-            />
-        </ProgressiveLoadingContainer>
-    )
+    const getItemComponent = (item) => {
+        if (firstOfTypes.includes(item.id)) {
+            item.firstOfType = true
+        }
+        return (
+            <ProgressiveLoadingContainer
+                key={item.i}
+                className={cx(
+                    item.type,
+                    'edit',
+                    getGridItemDomElementClassName(item.id)
+                )}
+                itemId={item.id}
+            >
+                <Item
+                    item={item}
+                    gridWidth={gridWidth.width}
+                    dashboardMode={EDIT}
+                />
+            </ProgressiveLoadingContainer>
+        )
+    }
 
     const getItemComponents = (items) =>
         items.map((item) => getItemComponent(item))

--- a/src/pages/print/PrintItemGrid.js
+++ b/src/pages/print/PrintItemGrid.js
@@ -4,6 +4,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { Item } from '../../components/Item/Item.js'
 import { PRINT } from '../../modules/dashboardModes.js'
+import { getFirstOfTypes } from '../../modules/getFirstOfType.js'
 import { getGridItemDomElementClassName } from '../../modules/getGridItemDomElementClassName.js'
 import { hasShape } from '../../modules/gridUtil.js'
 import { orArray } from '../../modules/util.js'
@@ -11,19 +12,26 @@ import { sGetPrintDashboardItems } from '../../reducers/printDashboard.js'
 import StaticGrid from './StaticGrid.js'
 
 const PrintItemGrid = ({ dashboardItems }) => {
-    const getItemComponent = (item) => (
-        <div
-            key={item.i}
-            className={cx(
-                item.type,
-                'print',
-                'oipp',
-                getGridItemDomElementClassName(item.id)
-            )}
-        >
-            <Item item={item} dashboardMode={PRINT} />
-        </div>
-    )
+    const firstOfTypes = getFirstOfTypes(dashboardItems)
+
+    const getItemComponent = (item) => {
+        if (firstOfTypes.includes(item.id)) {
+            item.firstOfType = true
+        }
+        return (
+            <div
+                key={item.i}
+                className={cx(
+                    item.type,
+                    'print',
+                    'oipp',
+                    getGridItemDomElementClassName(item.id)
+                )}
+            >
+                <Item item={item} dashboardMode={PRINT} />
+            </div>
+        )
+    }
 
     const getItemComponents = (items) =>
         items.map((item) => getItemComponent(item))

--- a/src/pages/print/PrintLayoutItemGrid.js
+++ b/src/pages/print/PrintLayoutItemGrid.js
@@ -60,13 +60,13 @@ class PrintLayoutItemGrid extends Component {
 
     getItemComponents = (items) => {
         const firstOfTypes = getFirstOfTypes(items)
-        items.forEach((item) => {
+
+        return items.map((item) => {
             if (firstOfTypes.includes(item.id)) {
                 item.firstOfType = true
             }
+            return this.getItemComponent(item)
         })
-
-        return items.map((item) => this.getItemComponent(item))
     }
 
     hideExtraPageBreaks() {

--- a/src/pages/print/PrintLayoutItemGrid.js
+++ b/src/pages/print/PrintLayoutItemGrid.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import { acUpdatePrintDashboardLayout } from '../../actions/printDashboard.js'
 import { Item } from '../../components/Item/Item.js'
 import { PRINT_LAYOUT } from '../../modules/dashboardModes.js'
+import { getFirstOfTypes } from '../../modules/getFirstOfType.js'
 import { getGridItemDomElementClassName } from '../../modules/getGridItemDomElementClassName.js'
 import { hasShape } from '../../modules/gridUtil.js'
 import { PAGEBREAK } from '../../modules/itemTypes.js'
@@ -57,8 +58,16 @@ class PrintLayoutItemGrid extends Component {
         )
     }
 
-    getItemComponents = (items) =>
-        items.map((item) => this.getItemComponent(item))
+    getItemComponents = (items) => {
+        const firstOfTypes = getFirstOfTypes(items)
+        items.forEach((item) => {
+            if (firstOfTypes.includes(item.id)) {
+                item.firstOfType = true
+            }
+        })
+
+        return items.map((item) => this.getItemComponent(item))
+    }
 
     hideExtraPageBreaks() {
         const sortedElements = getDomGridItemsSortedByYPos(

--- a/src/pages/view/ItemGrid.js
+++ b/src/pages/view/ItemGrid.js
@@ -9,6 +9,7 @@ import NoContentMessage from '../../components/NoContentMessage.js'
 import ProgressiveLoadingContainer from '../../components/ProgressiveLoadingContainer.js'
 import { useWindowDimensions } from '../../components/WindowDimensionsProvider.js'
 import { VIEW } from '../../modules/dashboardModes.js'
+import { getFirstOfTypes } from '../../modules/getFirstOfType.js'
 import { getGridItemDomElementClassName } from '../../modules/getGridItemDomElementClassName.js'
 import {
     GRID_ROW_HEIGHT_PX,
@@ -41,6 +42,7 @@ const ResponsiveItemGrid = ({ dashboardId, dashboardItems }) => {
     const [gridWidth, setGridWidth] = useState(0)
     const [forceLoad, setForceLoad] = useState(false)
     const { recordingState } = useCacheableSection(dashboardId)
+    const firstOfTypes = getFirstOfTypes(dashboardItems)
 
     useEffect(() => {
         setLayoutSm(
@@ -86,6 +88,10 @@ const ResponsiveItemGrid = ({ dashboardId, dashboardItems }) => {
     const getItemComponent = (item) => {
         if (!layoutSm.length) {
             return <div key={item.i} />
+        }
+
+        if (firstOfTypes.includes(item.id)) {
+            item.firstOfType = true
         }
 
         return (

--- a/src/reducers/iframePluginStatus.js
+++ b/src/reducers/iframePluginStatus.js
@@ -1,0 +1,46 @@
+import {
+    MAP,
+    EVENT_VISUALIZATION,
+    VISUALIZATION,
+} from '../modules/itemTypes.js'
+
+export const ADD_IFRAME_PLUGIN_STATUS = 'ADD_IFRAME_PLUGIN_STATUS'
+
+export const INSTALLATION_STATUS_READY = 'READY'
+export const INSTALLATION_STATUS_INSTALLING = 'INSTALLING'
+export const INSTALLATION_STATUS_UNKNOWN = 'UNKNOWN'
+
+export const DEFAULT_STATE_IFRAME_PLUGIN_STATUS = {
+    [MAP]: { firstId: null, status: INSTALLATION_STATUS_UNKNOWN },
+    [EVENT_VISUALIZATION]: {
+        firstId: null,
+        status: INSTALLATION_STATUS_UNKNOWN,
+    },
+    [VISUALIZATION]: {
+        firstId: null,
+        status: INSTALLATION_STATUS_UNKNOWN,
+    },
+}
+
+export default (
+    state = DEFAULT_STATE_IFRAME_PLUGIN_STATUS,
+    { type, value }
+) => {
+    switch (type) {
+        case ADD_IFRAME_PLUGIN_STATUS: {
+            return {
+                ...state,
+                [value.pluginType]: {
+                    firstId: value.firstId,
+                    status: value.status,
+                },
+            }
+        }
+        default:
+            return state
+    }
+}
+
+// selectors
+
+export const sGetIframePluginStatus = (state) => state.iframePluginStatus

--- a/src/reducers/iframePluginStatus.js
+++ b/src/reducers/iframePluginStatus.js
@@ -11,15 +11,9 @@ export const INSTALLATION_STATUS_INSTALLING = 'INSTALLING'
 export const INSTALLATION_STATUS_UNKNOWN = 'UNKNOWN'
 
 export const DEFAULT_STATE_IFRAME_PLUGIN_STATUS = {
-    [MAP]: { firstId: null, status: INSTALLATION_STATUS_UNKNOWN },
-    [EVENT_VISUALIZATION]: {
-        firstId: null,
-        status: INSTALLATION_STATUS_UNKNOWN,
-    },
-    [VISUALIZATION]: {
-        firstId: null,
-        status: INSTALLATION_STATUS_UNKNOWN,
-    },
+    [MAP]: INSTALLATION_STATUS_UNKNOWN,
+    [EVENT_VISUALIZATION]: INSTALLATION_STATUS_UNKNOWN,
+    [VISUALIZATION]: INSTALLATION_STATUS_UNKNOWN,
 }
 
 export default (
@@ -30,10 +24,7 @@ export default (
         case ADD_IFRAME_PLUGIN_STATUS: {
             return {
                 ...state,
-                [value.pluginType]: {
-                    firstId: value.firstId,
-                    status: value.status,
-                },
+                [value.pluginType]: value.status,
             }
         }
         default:

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import dashboards from './dashboards.js'
 import dashboardsFilter from './dashboardsFilter.js'
 import dimensions from './dimensions.js'
 import editDashboard from './editDashboard.js'
+import iframePluginStatus from './iframePluginStatus.js'
 import itemActiveTypes from './itemActiveTypes.js'
 import itemFilters from './itemFilters.js'
 import messages from './messages.js'
@@ -29,4 +30,5 @@ export default combineReducers({
     passiveViewRegistered,
     showDescription,
     itemActiveTypes,
+    iframePluginStatus,
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,12 +2169,12 @@
     react-beautiful-dnd "^10.1.1"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/app-adapter@10.3.5":
-  version "10.3.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-10.3.5.tgz#0e4c41d6567cff7f4bb8c75e970fc856b0c58fff"
-  integrity sha512-3XAPb/3nJF6cA6PPzu0WXeHi2LJWt46eNs73SCmxFOz+6fLCOXGSqNUw6VBMS0BleqhV1WXWn163IPHLz3mhqA==
+"@dhis2/app-adapter@10.3.7":
+  version "10.3.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-10.3.7.tgz#4d01b06ce972d48e71b694d0e98cd18c949f7bb6"
+  integrity sha512-T3AG+yW73HrtlDRl+a8lMg6Z4pVwjTXl4pJA458fVXomEKpHFilYV2GjY7nVRCUXC6bDLsV5rvDxkgHZqhSsSA==
   dependencies:
-    "@dhis2/pwa" "10.3.5"
+    "@dhis2/pwa" "10.3.7"
     moment "^2.24.0"
 
 "@dhis2/app-runtime-adapter-d2@^1.1.0":
@@ -2218,15 +2218,15 @@
   dependencies:
     lodash "^4.17.21"
 
-"@dhis2/app-shell@10.3.5":
-  version "10.3.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-10.3.5.tgz#d3466cbf7ee03e1007c1c2d27993e19a735eab54"
-  integrity sha512-LG8xeV2k43SYzikKmdVg+xq6zJlV6XOO8v5n43H7PysLGF9aRq29IRKHwyhXY3bA3Z/FFJGf6GnjLcHNUseJ5w==
+"@dhis2/app-shell@10.3.7":
+  version "10.3.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-10.3.7.tgz#f4eaf54cbf16044830a6f57f0992856c015eb3ab"
+  integrity sha512-vDjNSPwAlly0xZMk1lKIm3IO4eAyve4qF2RJ2tiKrHkXgWUokwsuboCCs/rQgqLcfnhwWj2NmGwheGYc49ZOEA==
   dependencies:
-    "@dhis2/app-adapter" "10.3.5"
+    "@dhis2/app-adapter" "10.3.7"
     "@dhis2/app-runtime" "^3.9.0"
     "@dhis2/d2-i18n" "^1.1.1"
-    "@dhis2/pwa" "10.3.5"
+    "@dhis2/pwa" "10.3.7"
     "@dhis2/ui" "^8.12.3"
     classnames "^2.2.6"
     moment "^2.29.1"
@@ -2239,10 +2239,10 @@
     typeface-roboto "^0.0.75"
     typescript "^3.6.3"
 
-"@dhis2/cli-app-scripts@^10.3.5":
-  version "10.3.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-10.3.5.tgz#0417f585f2515da4793a03e84f9d9dc6459196fd"
-  integrity sha512-J9mp9eiNbL6Uz/kyDypQtC/NkNaAG/tDwlnPeCAvZkIzFIUocvhzfbNM7ov67sSh6+onCa+R4l/oemXUB3nvaw==
+"@dhis2/cli-app-scripts@^10.3.7":
+  version "10.3.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-10.3.7.tgz#52e3af69ea19e0ed0ee765f4ce5cf9966f4ff7cf"
+  integrity sha512-QzrrsXKQ2Ammw6faSnC1EiVDnXmeErrAHw7NNyskQ1bCzDbgFvu9lzT+3zsAQoikaqdBawePY8KI6LXRENlWOw==
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.8.3"
@@ -2251,7 +2251,7 @@
     "@babel/preset-env" "^7.14.7"
     "@babel/preset-react" "^7.0.0"
     "@babel/preset-typescript" "^7.6.0"
-    "@dhis2/app-shell" "10.3.5"
+    "@dhis2/app-shell" "10.3.7"
     "@dhis2/cli-helpers-engine" "^3.2.0"
     "@jest/core" "^27.0.6"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.4"
@@ -2455,10 +2455,10 @@
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-3.1.2.tgz#65b8ad2da8cd2f72bc8b951049a6c9d1b97af3e9"
   integrity sha512-eM0jjLOWvtXWqSFp5YC4DHFpkP8Y1D2eUwGV7MBWjni+o27oesVan+oT7WHeOeLdlAd4acRJrnaaAyB4Ck1wGQ==
 
-"@dhis2/pwa@10.3.5":
-  version "10.3.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-10.3.5.tgz#9571fcc47a4624266933b7905aa547458d18b4d2"
-  integrity sha512-hvRqDx7jyqYzqX2quP5OW3MjkqsCTmtxqNr91tjaZtiA/MCrlcj+hFnH2DpK6BNJ48OVo4XauWllfa0bjGHCfg==
+"@dhis2/pwa@10.3.7":
+  version "10.3.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-10.3.7.tgz#7e94b249ce20d1c338bfba9f5f5242f9a7b8b077"
+  integrity sha512-YDPO/Jx6e9Btsg65mBjhA7OSLo0UFrHMHVemfKSkiOjZMqY5s+AnNQcNyxG0CxaBjUrgZmXsA7hfle9XAt1FSg==
   dependencies:
     idb "^6.0.0"
     workbox-core "^6.1.5"


### PR DESCRIPTION
Receives and plugin installation status and uses it to load first one plugin of each time to allow its service worker to install, then load the rest of the plugins of that type from the cache to save network resources

Implements [DHIS2-15097](https://dhis2.atlassian.net/browse/DHIS2-15097)

Pairs with https://github.com/dhis2/data-visualizer-app/pull/2273

---

### TODO

- [x] At the app level: make a store of plugin types and their installation states. Each state is initialized to `'unknown'`
    - [x] As plugins send their installation states, update this store
- [x] At the dashboard level, get the _first_ plugin of each type within that dashboard
- [x] In each `IframePlugin` component, check the installation status for this plugin type:
    - [x] If the status == `'unknown'` or `'installing'`, **only** load the iframe if this is the first plugin of its type on this dashboard. Otherwise, wait with a loading UI
    - [x] If the status == `'ready'` or `null` (i.e., "won't load"), go ahead and load the iframe

---

### Known issues

-   May cause incompatibility with some plugin versions

---

### Screenshots

Before and after these changes plus the other plugin changes - on a local 2.40dev instance, with "Disable cache" in dev tools, on the ANC dashboard, and after using "Clear site data" in the Chrome/Brave dev tools:

![anc-v40-original-load-perf](https://user-images.githubusercontent.com/49666798/235656022-ac5fa43f-3f42-4d70-b3fd-a7b15e9579d5.png)

![anc-v40-all-changes-load-perf](https://user-images.githubusercontent.com/49666798/235656044-6a19a452-e4c6-4c5e-8eb1-65ef5fd5a911.png)

[DHIS2-15097]: https://dhis2.atlassian.net/browse/DHIS2-15097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ