### PR TITLE
fix: avoid crash with TranslationDialog (DHIS2-19539)

### DIFF
--- a/config/testSetup.js
+++ b/config/testSetup.js
@@ -1,8 +1,13 @@
 import { configure } from '@testing-library/dom'
 import '@testing-library/jest-dom'
 import ResizeObserver from 'resize-observer-polyfill'
+import 'jest-webgl-canvas-mock'
 
 global.ResizeObserver = ResizeObserver
+
+// Emulate CSS.supports API
+// Needed with Highcharts >= 12.2.0
+global.CSS.supports = () => true
 
 configure({
     testIdAttribute: 'data-test',

--- a/config/testSetup.js
+++ b/config/testSetup.js
@@ -7,6 +7,7 @@ global.ResizeObserver = ResizeObserver
 
 // Emulate CSS.supports API
 // Needed with Highcharts >= 12.2.0
+// See: https://github.com/highcharts/highcharts/issues/22910
 global.CSS.supports = () => true
 
 configure({

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "^26.13.3",
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#1d503e539af811a4a9eb969fff1e59f6e1633da2",
         "@dhis2/app-runtime": "^3.13.2",
         "@dhis2/d2-i18n": "^1.1.3",
         "@dhis2/ui": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "eslint-plugin-cypress": "^3.3.0",
         "immutability-helper": "^3.1.1",
         "import": "^0.0.6",
+        "jest-webgl-canvas-mock": "^2.5.3",
         "patch-package": "^7",
         "postinstall-postinstall": "^2.1.0",
         "redux-mock-store": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "license": "BSD-3-Clause",
     "dependencies": {
-        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#1d503e539af811a4a9eb969fff1e59f6e1633da2",
+        "@dhis2/analytics": "^28.0.3",
         "@dhis2/app-runtime": "^3.13.2",
         "@dhis2/d2-i18n": "^1.1.3",
         "@dhis2/ui": "^10.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,10 +2330,9 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.13.3":
-  version "26.13.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.13.3.tgz#cf887e3f4cd9af7ad8968a9cc4171f95c9980d11"
-  integrity sha512-a11qX7Z/DF71Ac5eZD8+m0Xt1VObA0CBb8efZP4CFslXKkUK0c1WySTYWK86qTGoYNTPCJ6A/GacyZY8o/SsoQ==
+"@dhis2/analytics@git+https://github.com/d2-ci/analytics.git#1d503e539af811a4a9eb969fff1e59f6e1633da2":
+  version "28.0.1"
+  resolved "git+https://github.com/d2-ci/analytics.git#1d503e539af811a4a9eb969fff1e59f6e1633da2"
   dependencies:
     "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"
@@ -2344,7 +2343,7 @@
     crypto-js "^4.2.0"
     d2-utilizr "^0.2.16"
     d3-color "^1.2.3"
-    highcharts "^10.3.3"
+    highcharts "^12.1.2"
     lodash "^4.17.21"
     markdown-it "^13.0.1"
     mathjs "^9.4.2"
@@ -10054,10 +10053,10 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highcharts@^10.3.3:
-  version "10.3.3"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-10.3.3.tgz#b8acca24f2d4b1f2f726540734166e59e07b35c4"
-  integrity sha512-r7wgUPQI9tr3jFDn3XT36qsNwEIZYcfgz4mkKEA6E4nn5p86y+u1EZjazIG4TRkl5/gmGRtkBUiZW81g029RIw==
+highcharts@^12.1.2:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-12.2.0.tgz#264633af7e815f0f6291c0d570b1da12e323e9de"
+  integrity sha512-UUN+osTP3aeGc4KmoMuWAjzpKif8GYHFozzYI4O8h1ILGof25M/ZGBpXLvgqf1z0LVh7N9eG7i0HnzMfjcR4nA==
 
 history@^4.9.0:
   version "4.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2330,9 +2330,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@git+https://github.com/d2-ci/analytics.git#1d503e539af811a4a9eb969fff1e59f6e1633da2":
-  version "28.0.1"
-  resolved "git+https://github.com/d2-ci/analytics.git#1d503e539af811a4a9eb969fff1e59f6e1633da2"
+"@dhis2/analytics@^28.0.3":
+  version "28.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-28.0.3.tgz#49f5234e7df691759b16765f6d2f297aab8b71ae"
+  integrity sha512-xX5WXN+bkIonjJHWNb7piyFWZVD4sEQ02qPBI0Sa66IybQObtemF/LJD8imW3Vo8xrj4e6fQgsJ8N6zY1dKf3w==
   dependencies:
     "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7174,6 +7174,11 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==
+
 cssnano-preset-default@^5.2.12:
   version "5.2.12"
   resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz#ebe6596ec7030e62c3eb2b3c09f533c0644a9a97"
@@ -11724,6 +11729,14 @@ jest-watcher@^28.0.0:
     jest-util "^28.1.3"
     string-length "^4.0.1"
 
+jest-webgl-canvas-mock@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/jest-webgl-canvas-mock/-/jest-webgl-canvas-mock-2.5.3.tgz#22f6c6b27ccb54a0fa49ae24dfdaf144d211ffc7"
+  integrity sha512-aE5ym/VV8hpJgsu/zzmvJ/bhD4vnfAM9TY6TRQxQAy9lo3hxtNfa2rbLFt3Qx31spQd5fhlQHO58Aey6oFDxAA==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-worker@^26.2.1:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
@@ -13193,6 +13206,13 @@ moment@^2.24.0, moment@^2.29.1, moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
+
+moo-color@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.3.tgz#d56435f8359c8284d83ac58016df7427febece74"
+  integrity sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==
+  dependencies:
+    color-name "^1.1.4"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes an issue caused by [DHIS2-19539](https://dhis2.atlassian.net/browse/DHIS2-19539)

### Description

The fix is in the [analytics PR](https://github.com/dhis2/analytics/pull/1779).

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested N/A
- [ ] Cypress and/or Jest tests added/updated N/A
- [ ] Docs added N/A
- [x] d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/1779)
- [x] Tester approved (@HendrikThePendric)

---

### Screenshots

Before:
![Screenshot 2025-05-26 at 15 48 09](https://github.com/user-attachments/assets/7235e843-0906-4ce7-b48d-c99d09052d86)

After:
![Screenshot 2025-05-26 at 15 48 01](https://github.com/user-attachments/assets/5040c30f-1bde-454b-b427-d2e99a427a76)



[DHIS2-19539]: https://dhis2.atlassian.net/browse/DHIS2-19539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ