### PR TITLE
fix: hide "Open in app" for plugins without an app entrypoint (DHIS2-21739)

### DIFF
--- a/src/components/Item/AppItem/Item.jsx
+++ b/src/components/Item/AppItem/Item.jsx
@@ -63,7 +63,11 @@ const AppItem = ({
         (state, newState) => ({
             ...state,
             ...newState,
-            appUrl: `${appDetails?.launchUrl}${newState.appUrl}`,
+            // plugins without an app entrypoint have no launchUrl, so there is
+            // nothing to open in a standalone app (DHIS2-21739)
+            appUrl: appDetails?.launchUrl
+                ? `${appDetails.launchUrl}${newState.appUrl ?? ''}`
+                : undefined,
         }),
         {
             itemTitle: appDetails?.name,

--- a/src/components/Item/AppItem/Item.jsx
+++ b/src/components/Item/AppItem/Item.jsx
@@ -30,6 +30,7 @@ import ItemHeader from '../ItemHeader/ItemHeader.jsx'
 import MissingPluginMessage from '../ItemMessage/MissingPluginMessage.jsx'
 import { getIframeSrc } from './getIframeSrc.js'
 import { ItemContextMenu } from './ItemContextMenu.jsx'
+import { createItemDetailsReducer } from './itemDetailsReducer.js'
 import styles from './styles/AppItem.module.css'
 
 const AppItem = ({
@@ -60,15 +61,7 @@ const AppItem = ({
         item?.appKey && apps.find((app) => app.key === item.appKey)
 
     const [{ itemTitle, appUrl, onRemove }, setItemDetails] = useReducer(
-        (state, newState) => ({
-            ...state,
-            ...newState,
-            // plugins without an app entrypoint have no launchUrl, so there is
-            // nothing to open in a standalone app (DHIS2-21739)
-            appUrl: appDetails?.launchUrl
-                ? `${appDetails.launchUrl}${newState.appUrl ?? ''}`
-                : undefined,
-        }),
+        createItemDetailsReducer(appDetails),
         {
             itemTitle: appDetails?.name,
             appUrl: appDetails?.launchUrl,
@@ -166,7 +159,6 @@ const AppItem = ({
             isViewMode(dashboardMode) &&
             !isSlideshowView ? (
                 <ItemContextMenu
-                    item={item}
                     appName={appDetails.name}
                     appUrl={appUrl}
                     enterFullscreen={() => dispatch(acSetSlideshow(sortIndex))}

--- a/src/components/Item/AppItem/ItemContextMenu.jsx
+++ b/src/components/Item/AppItem/ItemContextMenu.jsx
@@ -27,9 +27,13 @@ export const ItemContextMenu = ({
 
     const { allowVisOpenInApp, allowVisFullscreen } = useSystemSettings()
 
-    const noOptionsEnabled = !allowVisOpenInApp && !allowVisFullscreen
+    // plugins without an app entrypoint have no appUrl, so there is nothing to
+    // open in a standalone app (DHIS2-21739)
+    const openInAppEnabled = allowVisOpenInApp && !!appUrl
 
-    if (noOptionsEnabled || (!allowVisOpenInApp && loadItemFailed)) {
+    const noOptionsEnabled = !openInAppEnabled && !allowVisFullscreen
+
+    if (noOptionsEnabled || (!openInAppEnabled && loadItemFailed)) {
         return null
     }
 
@@ -63,7 +67,7 @@ export const ItemContextMenu = ({
                     onClickOutside={closeMenu}
                 >
                     <Menu dense>
-                        {allowVisOpenInApp && !isSmallScreen(width) && (
+                        {openInAppEnabled && !isSmallScreen(width) && (
                             <MenuItem
                                 icon={<IconLaunch16 />}
                                 disabledWhenOffline={false}

--- a/src/components/Item/AppItem/__tests__/ItemContextMenu.spec.jsx
+++ b/src/components/Item/AppItem/__tests__/ItemContextMenu.spec.jsx
@@ -1,0 +1,84 @@
+import { fireEvent } from '@testing-library/dom'
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+import { useSystemSettings } from '../../../AppDataProvider/AppDataProvider.jsx'
+import WindowDimensionsProvider from '../../../WindowDimensionsProvider.jsx'
+import { ItemContextMenu } from '../ItemContextMenu.jsx'
+
+jest.mock('../../../AppDataProvider/AppDataProvider', () => {
+    return {
+        __esModule: true,
+        default: jest.fn((children) => <div>{children}</div>),
+        useSystemSettings: jest.fn(),
+    }
+})
+
+jest.mock('@dhis2/app-runtime', () => ({
+    useDhis2ConnectionStatus: jest.fn(() => ({
+        isConnected: true,
+        isDisconnected: false,
+    })),
+    useConfig: jest.fn(() => ({ baseUrl: 'dhis2' })),
+}))
+
+const mockSystemSettingsDefault = {
+    allowVisOpenInApp: true,
+    allowVisFullscreen: true,
+}
+
+const defaultProps = {
+    appName: 'My Plugin',
+    appUrl: 'https://iframe/app/launch',
+    enterFullscreen: Function.prototype,
+    loadItemFailed: false,
+}
+
+test('renders "Open in [app]" when the app has an entrypoint (appUrl)', async () => {
+    useSystemSettings.mockReturnValue(mockSystemSettingsDefault)
+
+    const { getByRole, queryByText } = render(
+        <WindowDimensionsProvider>
+            <ItemContextMenu {...defaultProps} />
+        </WindowDimensionsProvider>
+    )
+
+    fireEvent.click(getByRole('button'))
+
+    await waitFor(() => {
+        expect(queryByText('Open in My Plugin')).toBeTruthy()
+        expect(queryByText('View fullscreen')).toBeTruthy()
+    })
+})
+
+test('does not render "Open in [app]" when the plugin has no entrypoint (no appUrl)', async () => {
+    useSystemSettings.mockReturnValue(mockSystemSettingsDefault)
+
+    const { getByRole, queryByText } = render(
+        <WindowDimensionsProvider>
+            <ItemContextMenu {...defaultProps} appUrl={undefined} />
+        </WindowDimensionsProvider>
+    )
+
+    fireEvent.click(getByRole('button'))
+
+    await waitFor(() => {
+        expect(queryByText(/Open in/i)).toBeNull()
+        // the menu is still useful for fullscreen
+        expect(queryByText('View fullscreen')).toBeTruthy()
+    })
+})
+
+test('renders null when the plugin has no entrypoint and fullscreen is disabled', () => {
+    useSystemSettings.mockReturnValue({
+        allowVisOpenInApp: true,
+        allowVisFullscreen: false,
+    })
+
+    const { container } = render(
+        <WindowDimensionsProvider>
+            <ItemContextMenu {...defaultProps} appUrl={undefined} />
+        </WindowDimensionsProvider>
+    )
+
+    expect(container.firstChild).toBeNull()
+})

--- a/src/components/Item/AppItem/__tests__/itemDetailsReducer.spec.js
+++ b/src/components/Item/AppItem/__tests__/itemDetailsReducer.spec.js
@@ -1,0 +1,30 @@
+import { createItemDetailsReducer } from '../itemDetailsReducer.js'
+
+// DHIS2-21739: a plugin-only app has a pluginLaunchUrl but no launchUrl, so
+// there is no standalone app to open. The reducer used to build the href as
+// `${launchUrl}${appUrl}`, yielding the literal string "undefinedundefined".
+
+test('returns undefined appUrl when the app has no launchUrl (entrypoint)', () => {
+    const reducer = createItemDetailsReducer({ name: 'My Plugin' })
+
+    // the plugin reports its own route via appUrl, but there is nothing to open
+    const state = reducer({}, { appUrl: '/some/route' })
+
+    expect(state.appUrl).toBeUndefined()
+})
+
+test('builds the launchUrl-based appUrl for apps with an entrypoint', () => {
+    const reducer = createItemDetailsReducer({ launchUrl: 'https://host/app' })
+
+    const state = reducer({}, { appUrl: '/dashboard' })
+
+    expect(state.appUrl).toBe('https://host/app/dashboard')
+})
+
+test('falls back to the launchUrl when no appUrl is provided', () => {
+    const reducer = createItemDetailsReducer({ launchUrl: 'https://host/app' })
+
+    const state = reducer({}, { itemTitle: 'X' })
+
+    expect(state.appUrl).toBe('https://host/app')
+})

--- a/src/components/Item/AppItem/__tests__/itemDetailsReducer.spec.js
+++ b/src/components/Item/AppItem/__tests__/itemDetailsReducer.spec.js
@@ -1,9 +1,5 @@
 import { createItemDetailsReducer } from '../itemDetailsReducer.js'
 
-// DHIS2-21739: a plugin-only app has a pluginLaunchUrl but no launchUrl, so
-// there is no standalone app to open. The reducer used to build the href as
-// `${launchUrl}${appUrl}`, yielding the literal string "undefinedundefined".
-
 test('returns undefined appUrl when the app has no launchUrl (entrypoint)', () => {
     const reducer = createItemDetailsReducer({ name: 'My Plugin' })
 

--- a/src/components/Item/AppItem/itemDetailsReducer.js
+++ b/src/components/Item/AppItem/itemDetailsReducer.js
@@ -1,0 +1,10 @@
+// plugins without an app entrypoint have no launchUrl, so there is nothing to
+// open in a standalone app - keep appUrl undefined rather than stringifying
+// "undefined" into a broken href (DHIS2-21739)
+export const createItemDetailsReducer = (appDetails) => (state, newState) => ({
+    ...state,
+    ...newState,
+    appUrl: appDetails?.launchUrl
+        ? `${appDetails.launchUrl}${newState.appUrl ?? ''}`
+        : undefined,
+})


### PR DESCRIPTION
Implements [DHIS2-21739](https://dhis2.atlassian.net/browse/DHIS2-21739)

### Description

Plugin-only apps (installed without an app entrypoint in `d2.config.js`, e.g. Capture Growth Chart) are served with a `pluginLaunchUrl` but no `launchUrl` — there is no standalone app to open. Despite this, the dashboard item's ⋯ menu still showed an **"Open in {app}"** option. Clicking it navigated to a broken relative URL (`.../dhis-web-dashboard/undefinedundefined`) and 404'd, because the app URL was built by concatenating `` `${appDetails.launchUrl}${newState.appUrl}` `` where both parts were `undefined`.

This PR:

- Only exposes the "Open in {app}" option when the app actually has a launch URL (`openInAppEnabled = allowVisOpenInApp && !!appUrl`). The ⋯ menu is still shown for such plugins when "View fullscreen" is available.
- Stops the reducer from stringifying `undefined` when there is no `launchUrl`, so `appUrl` is `undefined` (not `"undefinedundefined"`) for entrypoint-less plugins.

AI Assisted.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [x] Tested with and without global shell
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added — _N/A_
- [x] d2-ci dependency replaced (requires https://github.com/dhis2/analytics/pull/XXX) — _N/A_
- [x] Small screen tested
- [x] Offline tested
- [x] Tester approved (@HendrikThePendric)

---

### ToDos

N/A

---

### Known issues

N/A

---

### Screenshots

_supporting text_


[DHIS2-21739]: https://dhis2.atlassian.net/browse/DHIS2-21739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ